### PR TITLE
Lab2 rwlock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ OBJS = \
   $K/virtio_disk.o \
   $K/buddy.o \
   $K/list.o \
+  $K/proc_list.o \
 
 # riscv64-unknown-elf- or riscv64-linux-gnu-
 # perhaps in /opt/riscv/bin

--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,7 @@ UPROGS=\
 	$U/_dumptests\
 	$U/_dump2tests\
 	$U/_alloctest\
+	$U/_proclisttest\
 
 fs.img: mkfs/mkfs README $(UPROGS)
 	mkfs/mkfs fs.img README $(UPROGS)

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,9 @@ OBJS = \
   $K/sysfile.o \
   $K/kernelvec.o \
   $K/plic.o \
-  $K/virtio_disk.o
+  $K/virtio_disk.o \
+  $K/buddy.o \
+  $K/list.o \
 
 # riscv64-unknown-elf- or riscv64-linux-gnu-
 # perhaps in /opt/riscv/bin
@@ -106,7 +108,7 @@ $U/%tests.S.o : $U/%tests.S
 $U/%tests.o: $U/%tests.c
 	$(CC) $(CFLAGS) -c -o $@ $<
 
-$U/_%tests: $U/%tests.o $U/%tests.S.o $(ULIB)
+_%tests: %tests.o %tests.S.o $(ULIB)
 	$(LD) $(LDFLAGS) -T $U/user.ld -o $@ $^
 	$(OBJDUMP) -S $@ > $*.asm
 	$(OBJDUMP) -t $@ | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > $*.sym
@@ -146,6 +148,7 @@ UPROGS=\
 	$U/_pingpong\
 	$U/_dumptests\
 	$U/_dump2tests\
+	$U/_alloctest\
 
 fs.img: mkfs/mkfs README $(UPROGS)
 	mkfs/mkfs fs.img README $(UPROGS)

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ OBJS = \
   $K/buddy.o \
   $K/list.o \
   $K/proc_list.o \
+  $K/rwlock.o \
 
 # riscv64-unknown-elf- or riscv64-linux-gnu-
 # perhaps in /opt/riscv/bin

--- a/kernel/buddy.c
+++ b/kernel/buddy.c
@@ -1,0 +1,333 @@
+#include "types.h"
+#include "param.h"
+#include "memlayout.h"
+#include "spinlock.h"
+#include "riscv.h"
+#include "defs.h"
+#include "list.h"
+
+// Buddy allocator
+
+static int nsizes;  // the number of entries in bd_sizes array
+
+#define LEAF_SIZE 16          // The smallest block size
+#define MAXSIZE (nsizes - 1)  // Largest index in bd_sizes array
+#define BLK_SIZE(k) ((1L << (k)) * LEAF_SIZE)  // Size of block at size k
+#define HEAP_SIZE BLK_SIZE(MAXSIZE)
+#define NBLK(k) (1 << (MAXSIZE - k))  // Number of block at size k
+#define ROUNDUP(n, sz) \
+  (((((n)-1) / (sz)) + 1) * (sz))  // Round up to the next multiple of sz
+
+typedef struct list Bd_list;
+
+// The allocator has sz_info for each size k. Each sz_info has a free
+// list, an array alloc to keep track which blocks have been
+// allocated, and an split array to to keep track which blocks have
+// been split.  The arrays are of type char (which is 1 byte), but the
+// allocator uses 1 bit per block (thus, one char records the info of
+// 8 blocks).
+struct sz_info {
+  Bd_list free;
+  char *alloc;
+  char *split;
+};
+typedef struct sz_info Sz_info;
+
+static Sz_info *bd_sizes;
+static void *bd_base;  // start address of memory managed by the buddy allocator
+static struct spinlock lock;
+
+// Return 1 if bit at position index in array is set to 1
+int bit_isset(char *array, int index) {
+  char b = array[index / 8];
+  char m = (1 << (index % 8));
+  return (b & m) == m;
+}
+
+// Set bit at position index in array to 1
+void bit_set(char *array, int index) {
+  char b = array[index / 8];
+  char m = (1 << (index % 8));
+  array[index / 8] = (b | m);
+}
+
+// Clear bit at position index in array
+void bit_clear(char *array, int index) {
+  char b = array[index / 8];
+  char m = (1 << (index % 8));
+  array[index / 8] = (b & ~m);
+}
+
+// Print a bit vector as a list of ranges of 1 bits
+void bd_print_vector(char *vector, int len) {
+  int last, lb;
+
+  last = 1;
+  lb = 0;
+  for (int b = 0; b < len; b++) {
+    if (last == bit_isset(vector, b)) continue;
+    if (last == 1) printf(" [%d, %d)", lb, b);
+    lb = b;
+    last = bit_isset(vector, b);
+  }
+  if (lb == 0 || last == 1) {
+    printf(" [%d, %d)", lb, len);
+  }
+  printf("\n");
+}
+
+// Print buddy's data structures
+void bd_print() {
+  for (int k = 0; k < nsizes; k++) {
+    printf("size %d (blksz %d nblk %d): free list: ", k, BLK_SIZE(k), NBLK(k));
+    lst_print(&bd_sizes[k].free);
+    printf("  alloc:");
+    bd_print_vector(bd_sizes[k].alloc, NBLK(k));
+    if (k > 0) {
+      printf("  split:");
+      bd_print_vector(bd_sizes[k].split, NBLK(k));
+    }
+  }
+}
+
+// What is the first k such that 2^k >= n?
+int firstk(uint64 n) {
+  int k = 0;
+  uint64 size = LEAF_SIZE;
+
+  while (size < n) {
+    k++;
+    size *= 2;
+  }
+  return k;
+}
+
+// Compute the block index for address p at size k
+int blk_index(int k, char *p) {
+  int n = p - (char *)bd_base;
+  return n / BLK_SIZE(k);
+}
+
+// Convert a block index at size k back into an address
+void *addr(int k, int bi) {
+  int n = bi * BLK_SIZE(k);
+  return (char *)bd_base + n;
+}
+
+// allocate nbytes, but malloc won't return anything smaller than LEAF_SIZE
+void *bd_malloc(uint64 nbytes) {
+  int fk, k;
+
+  acquire(&lock);
+
+  // Find a free block >= nbytes, starting with smallest k possible
+  fk = firstk(nbytes);
+  for (k = fk; k < nsizes; k++) {
+    if (!lst_empty(&bd_sizes[k].free)) break;
+  }
+  if (k >= nsizes) {  // No free blocks?
+    release(&lock);
+    return 0;
+  }
+
+  // Found a block; pop it and potentially split it.
+  char *p = lst_pop(&bd_sizes[k].free);
+  bit_set(bd_sizes[k].alloc, blk_index(k, p));
+  for (; k > fk; k--) {
+    // split a block at size k and mark one half allocated at size k-1
+    // and put the buddy on the free list at size k-1
+    char *q = p + BLK_SIZE(k - 1);  // p's buddy
+    bit_set(bd_sizes[k].split, blk_index(k, p));
+    bit_set(bd_sizes[k - 1].alloc, blk_index(k - 1, p));
+    lst_push(&bd_sizes[k - 1].free, q);
+  }
+  release(&lock);
+
+  return p;
+}
+
+// Find the size of the block that p points to.
+int size(char *p) {
+  for (int k = 0; k < nsizes; k++) {
+    if (bit_isset(bd_sizes[k + 1].split, blk_index(k + 1, p))) {
+      return k;
+    }
+  }
+  return 0;
+}
+
+// Free memory pointed to by p, which was earlier allocated using
+// bd_malloc.
+void bd_free(void *p) {
+  void *q;
+  int k;
+
+  acquire(&lock);
+  for (k = size(p); k < MAXSIZE; k++) {
+    int bi = blk_index(k, p);
+    int buddy = (bi % 2 == 0) ? bi + 1 : bi - 1;
+    bit_clear(bd_sizes[k].alloc, bi);           // free p at size k
+    if (bit_isset(bd_sizes[k].alloc, buddy)) {  // is buddy allocated?
+      break;                                    // break out of loop
+    }
+    // budy is free; merge with buddy
+    q = addr(k, buddy);
+    lst_remove(q);  // remove buddy from free list
+    if (buddy % 2 == 0) {
+      p = q;
+    }
+    // at size k+1, mark that the merged buddy pair isn't split
+    // anymore
+    bit_clear(bd_sizes[k + 1].split, blk_index(k + 1, p));
+  }
+  lst_push(&bd_sizes[k].free, p);
+  release(&lock);
+}
+
+// Compute the first block at size k that doesn't contain p
+int blk_index_next(int k, char *p) {
+  int n = (p - (char *)bd_base) / BLK_SIZE(k);
+  if ((p - (char *)bd_base) % BLK_SIZE(k) != 0) n++;
+  return n;
+}
+
+int log2(uint64 n) {
+  int k = 0;
+  while (n > 1) {
+    k++;
+    n = n >> 1;
+  }
+  return k;
+}
+
+// Mark memory from [start, stop), starting at size 0, as allocated.
+void bd_mark(void *start, void *stop) {
+  int bi, bj;
+
+  if (((uint64)start % LEAF_SIZE != 0) || ((uint64)stop % LEAF_SIZE != 0))
+    panic("bd_mark");
+
+  for (int k = 0; k < nsizes; k++) {
+    bi = blk_index(k, start);
+    bj = blk_index_next(k, stop);
+    for (; bi < bj; bi++) {
+      if (k > 0) {
+        // if a block is allocated at size k, mark it as split too.
+        bit_set(bd_sizes[k].split, bi);
+      }
+      bit_set(bd_sizes[k].alloc, bi);
+    }
+  }
+}
+
+// If a block is marked as allocated and the buddy is free, put the
+// buddy on the free list at size k.
+int bd_initfree_pair(int k, int bi) {
+  int buddy = (bi % 2 == 0) ? bi + 1 : bi - 1;
+  int free = 0;
+  if (bit_isset(bd_sizes[k].alloc, bi) != bit_isset(bd_sizes[k].alloc, buddy)) {
+    // one of the pair is free
+    free = BLK_SIZE(k);
+    if (bit_isset(bd_sizes[k].alloc, bi))
+      lst_push(&bd_sizes[k].free, addr(k, buddy));  // put buddy on free list
+    else
+      lst_push(&bd_sizes[k].free, addr(k, bi));  // put bi on free list
+  }
+  return free;
+}
+
+// Initialize the free lists for each size k.  For each size k, there
+// are only two pairs that may have a buddy that should be on free list:
+// bd_left and bd_right.
+int bd_initfree(void *bd_left, void *bd_right) {
+  int free = 0;
+
+  for (int k = 0; k < MAXSIZE; k++) {  // skip max size
+    int left = blk_index_next(k, bd_left);
+    int right = blk_index(k, bd_right);
+    free += bd_initfree_pair(k, left);
+    if (right <= left) continue;
+    free += bd_initfree_pair(k, right);
+  }
+  return free;
+}
+
+// Mark the range [bd_base,p) as allocated
+int bd_mark_data_structures(char *p) {
+  int meta = p - (char *)bd_base;
+  printf("bd: %d meta bytes for managing %d bytes of memory\n", meta,
+         BLK_SIZE(MAXSIZE));
+  bd_mark(bd_base, p);
+  return meta;
+}
+
+// Mark the range [end, HEAPSIZE) as allocated
+int bd_mark_unavailable(void *end, void *left) {
+  int unavailable = BLK_SIZE(MAXSIZE) - (end - bd_base);
+  if (unavailable > 0) unavailable = ROUNDUP(unavailable, LEAF_SIZE);
+  printf("bd: 0x%x bytes unavailable\n", unavailable);
+
+  void *bd_end = bd_base + BLK_SIZE(MAXSIZE) - unavailable;
+  bd_mark(bd_end, bd_base + BLK_SIZE(MAXSIZE));
+  return unavailable;
+}
+
+// Initialize the buddy allocator: it manages memory from [base, end).
+void bd_init(void *base, void *end) {
+  char *p = (char *)ROUNDUP((uint64)base, LEAF_SIZE);
+  int sz;
+
+  initlock(&lock, "buddy");
+  bd_base = (void *)p;
+
+  // compute the number of sizes we need to manage [base, end)
+  nsizes = log2(((char *)end - p) / LEAF_SIZE) + 1;
+  if ((char *)end - p > BLK_SIZE(MAXSIZE)) {
+    nsizes++;  // round up to the next power of 2
+  }
+
+  printf("bd: memory sz is %d bytes; allocate an size array of length %d\n",
+         (char *)end - p, nsizes);
+
+  // allocate bd_sizes array
+  bd_sizes = (Sz_info *)p;
+  p += sizeof(Sz_info) * nsizes;
+  memset(bd_sizes, 0, sizeof(Sz_info) * nsizes);
+
+  // initialize free list and allocate the alloc array for each size k
+  for (int k = 0; k < nsizes; k++) {
+    lst_init(&bd_sizes[k].free);
+    sz = sizeof(char) * ROUNDUP(NBLK(k), 8) / 8;
+    bd_sizes[k].alloc = p;
+    memset(bd_sizes[k].alloc, 0, sz);
+    p += sz;
+  }
+
+  // allocate the split array for each size k, except for k = 0, since
+  // we will not split blocks of size k = 0, the smallest size.
+  for (int k = 1; k < nsizes; k++) {
+    sz = sizeof(char) * (ROUNDUP(NBLK(k), 8)) / 8;
+    bd_sizes[k].split = p;
+    memset(bd_sizes[k].split, 0, sz);
+    p += sz;
+  }
+  p = (char *)ROUNDUP((uint64)p, LEAF_SIZE);
+
+  // done allocating; mark the memory range [base, p) as allocated, so
+  // that buddy will not hand out that memory.
+  int meta = bd_mark_data_structures(p);
+
+  // mark the unavailable memory range [end, HEAP_SIZE) as allocated,
+  // so that buddy will not hand out that memory.
+  int unavailable = bd_mark_unavailable(end, p);
+  void *bd_end = bd_base + BLK_SIZE(MAXSIZE) - unavailable;
+
+  // initialize free lists for each size k
+  int free = bd_initfree(p, bd_end);
+
+  // check if the amount that is free is what we expect
+  if (free != BLK_SIZE(MAXSIZE) - meta - unavailable) {
+    printf("free %d %d\n", free, BLK_SIZE(MAXSIZE) - meta - unavailable);
+    panic("bd_init: free mem");
+  }
+}

--- a/kernel/buddy.c
+++ b/kernel/buddy.c
@@ -243,6 +243,9 @@ int bd_initfree(void *bd_left, void *bd_right) {
   int free = 0;
 
   for (int k = 0; k < MAXSIZE; k++) {  // skip max size
+    printf("Block size: %d\n", k);
+    printf("Alloc:");
+    bd_print_vector(bd_sizes[k].alloc, NBLK(k));
     int left = blk_index_next(k, bd_left);
     int right = blk_index(k, bd_right);
     free += bd_initfree_pair(k, left);
@@ -255,7 +258,7 @@ int bd_initfree(void *bd_left, void *bd_right) {
 // Mark the range [bd_base,p) as allocated
 int bd_mark_data_structures(char *p) {
   int meta = p - (char *)bd_base;
-  printf("bd: %d meta bytes for managing %d bytes of memory\n", meta,
+  printf("bd: 0x%x meta bytes for managing 0x%x bytes of memory\n", meta,
          BLK_SIZE(MAXSIZE));
   bd_mark(bd_base, p);
   return meta;
@@ -286,7 +289,7 @@ void bd_init(void *base, void *end) {
     nsizes++;  // round up to the next power of 2
   }
 
-  printf("bd: memory sz is %d bytes; allocate an size array of length %d\n",
+  printf("bd: memory sz is 0x%x bytes; allocate an size array of length %d\n",
          (char *)end - p, nsizes);
 
   // allocate bd_sizes array
@@ -327,7 +330,7 @@ void bd_init(void *base, void *end) {
 
   // check if the amount that is free is what we expect
   if (free != BLK_SIZE(MAXSIZE) - meta - unavailable) {
-    printf("free %d %d\n", free, BLK_SIZE(MAXSIZE) - meta - unavailable);
+    printf("free 0x%x %d\n", free, BLK_SIZE(MAXSIZE) - meta - unavailable);
     panic("bd_init: free mem");
   }
 }

--- a/kernel/buddy.c
+++ b/kernel/buddy.c
@@ -28,7 +28,7 @@ typedef struct list Bd_list;
 // 8 blocks).
 struct sz_info {
   Bd_list free;
-  char *alloc;
+  char *xor_alloc;
   char *split;
 };
 typedef struct sz_info Sz_info;
@@ -58,6 +58,12 @@ void bit_clear(char *array, int index) {
   array[index / 8] = (b & ~m);
 }
 
+void bit_invert(char *array, int index) {
+  char b = array[index / 8];
+  char m = (1 << (index % 8));
+  array[index / 8] = (b ^ m);
+}
+
 // Print a bit vector as a list of ranges of 1 bits
 void bd_print_vector(char *vector, int len) {
   int last, lb;
@@ -66,7 +72,7 @@ void bd_print_vector(char *vector, int len) {
   lb = 0;
   for (int b = 0; b < len; b++) {
     if (last == bit_isset(vector, b)) continue;
-    if (last == 1) printf(" [%d, %d)", lb, b);
+    if (last == 1 && b != 0) printf(" [%d, %d)", lb, b);
     lb = b;
     last = bit_isset(vector, b);
   }
@@ -81,8 +87,8 @@ void bd_print() {
   for (int k = 0; k < nsizes; k++) {
     printf("size %d (blksz %d nblk %d): free list: ", k, BLK_SIZE(k), NBLK(k));
     lst_print(&bd_sizes[k].free);
-    printf("  alloc:");
-    bd_print_vector(bd_sizes[k].alloc, NBLK(k));
+    printf("  xor alloc:");
+    bd_print_vector(bd_sizes[k].xor_alloc, NBLK(k) / 2);
     if (k > 0) {
       printf("  split:");
       bd_print_vector(bd_sizes[k].split, NBLK(k));
@@ -132,13 +138,13 @@ void *bd_malloc(uint64 nbytes) {
 
   // Found a block; pop it and potentially split it.
   char *p = lst_pop(&bd_sizes[k].free);
-  bit_set(bd_sizes[k].alloc, blk_index(k, p));
+  bit_invert(bd_sizes[k].xor_alloc, blk_index(k, p) / 2);
   for (; k > fk; k--) {
     // split a block at size k and mark one half allocated at size k-1
     // and put the buddy on the free list at size k-1
     char *q = p + BLK_SIZE(k - 1);  // p's buddy
     bit_set(bd_sizes[k].split, blk_index(k, p));
-    bit_set(bd_sizes[k - 1].alloc, blk_index(k - 1, p));
+    bit_invert(bd_sizes[k - 1].xor_alloc, blk_index(k - 1, p) / 2);
     lst_push(&bd_sizes[k - 1].free, q);
   }
   release(&lock);
@@ -163,11 +169,12 @@ void bd_free(void *p) {
   int k;
 
   acquire(&lock);
+  // printf("Free of block size %d\n", size(p));
   for (k = size(p); k < MAXSIZE; k++) {
     int bi = blk_index(k, p);
     int buddy = (bi % 2 == 0) ? bi + 1 : bi - 1;
-    bit_clear(bd_sizes[k].alloc, bi);           // free p at size k
-    if (bit_isset(bd_sizes[k].alloc, buddy)) {  // is buddy allocated?
+    bit_invert(bd_sizes[k].xor_alloc, bi / 2);
+    if (bit_isset(bd_sizes[k].xor_alloc, buddy / 2)) {  // is buddy allocated?
       break;                                    // break out of loop
     }
     // budy is free; merge with buddy
@@ -215,23 +222,25 @@ void bd_mark(void *start, void *stop) {
         // if a block is allocated at size k, mark it as split too.
         bit_set(bd_sizes[k].split, bi);
       }
-      bit_set(bd_sizes[k].alloc, bi);
+      bit_invert(bd_sizes[k].xor_alloc, bi / 2);
     }
   }
 }
 
 // If a block is marked as allocated and the buddy is free, put the
 // buddy on the free list at size k.
-int bd_initfree_pair(int k, int bi) {
+int bd_initfree_pair(int k, int bi, int left) {
   int buddy = (bi % 2 == 0) ? bi + 1 : bi - 1;
   int free = 0;
-  if (bit_isset(bd_sizes[k].alloc, bi) != bit_isset(bd_sizes[k].alloc, buddy)) {
+  if (bit_isset(bd_sizes[k].xor_alloc, bi / 2)) {
     // one of the pair is free
     free = BLK_SIZE(k);
-    if (bit_isset(bd_sizes[k].alloc, bi))
-      lst_push(&bd_sizes[k].free, addr(k, buddy));  // put buddy on free list
+    void *addr_to_push;
+    if (left)
+      addr_to_push = addr(k, (buddy > bi ? buddy : bi));  // put right on the free list
     else
-      lst_push(&bd_sizes[k].free, addr(k, bi));  // put bi on free list
+      addr_to_push = addr(k, (buddy < bi ? buddy : bi));  // put left on the free list
+    lst_push(&bd_sizes[k].free, addr_to_push);
   }
   return free;
 }
@@ -243,14 +252,11 @@ int bd_initfree(void *bd_left, void *bd_right) {
   int free = 0;
 
   for (int k = 0; k < MAXSIZE; k++) {  // skip max size
-    printf("Block size: %d\n", k);
-    printf("Alloc:");
-    bd_print_vector(bd_sizes[k].alloc, NBLK(k));
     int left = blk_index_next(k, bd_left);
     int right = blk_index(k, bd_right);
-    free += bd_initfree_pair(k, left);
+    free += bd_initfree_pair(k, left, 1);
     if (right <= left) continue;
-    free += bd_initfree_pair(k, right);
+    free += bd_initfree_pair(k, right, 0);
   }
   return free;
 }
@@ -300,9 +306,9 @@ void bd_init(void *base, void *end) {
   // initialize free list and allocate the alloc array for each size k
   for (int k = 0; k < nsizes; k++) {
     lst_init(&bd_sizes[k].free);
-    sz = sizeof(char) * ROUNDUP(NBLK(k), 8) / 8;
-    bd_sizes[k].alloc = p;
-    memset(bd_sizes[k].alloc, 0, sz);
+    sz = sizeof(char) * ROUNDUP(NBLK(k), 16) / 16;
+    bd_sizes[k].xor_alloc = p;
+    memset(bd_sizes[k].xor_alloc, 0, sz);
     p += sz;
   }
 
@@ -330,7 +336,7 @@ void bd_init(void *base, void *end) {
 
   // check if the amount that is free is what we expect
   if (free != BLK_SIZE(MAXSIZE) - meta - unavailable) {
-    printf("free 0x%x %d\n", free, BLK_SIZE(MAXSIZE) - meta - unavailable);
+    printf("free %d %d\n", free, BLK_SIZE(MAXSIZE) - meta - unavailable);
     panic("bd_init: free mem");
   }
 }

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -9,6 +9,7 @@ struct sleeplock;
 struct stat;
 struct superblock;
 struct list;
+struct proc_list;
 
 // bio.c
 void            binit(void);
@@ -195,6 +196,14 @@ void lst_push(struct list*, void *);
 void *lst_pop(struct list*);
 void lst_print(struct list*);
 int lst_empty(struct list*);
+
+// proc_list.c
+void proc_lst_init(struct proc_list*);
+void proc_lst_remove(struct proc_list*);
+void proc_lst_push(struct proc_list*, struct proc_list*);
+void roc_lst_print(struct proc_list*);
+int proc_lst_empty(struct proc_list*);
+struct proc_list *get_proc_list_by_proc(struct proc*, struct proc_list*);
 
 // buddy.c
 void bd_init(void *, void *);

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -111,7 +111,7 @@ int             either_copyin(void *dst, int user_src, uint64 src, uint64 len);
 void            procdump(void);
 int             dump(void);
 int             dump2(int pid, int register_num, uint64 return_value_addr);
-int             neighbors(int, uint64, uint64);
+int             neighbors(int, uint64, uint64, uint64, uint64);
 
 // swtch.S
 void            swtch(struct context*, struct context*);

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -10,6 +10,7 @@ struct stat;
 struct superblock;
 struct list;
 struct proc_list;
+struct rwlock;
 
 // bio.c
 void            binit(void);
@@ -204,12 +205,20 @@ void proc_lst_remove(struct proc_list*);
 void proc_lst_push(struct proc_list*, struct proc_list*);
 void roc_lst_print(struct proc_list*);
 int proc_lst_empty(struct proc_list*);
+int proc_lst_size(struct proc_list*);
 struct proc_list *get_proc_list_by_proc(struct proc*, struct proc_list*);
 
 // buddy.c
 void bd_init(void *, void *);
 void *bd_malloc(uint64);
 void bd_free(void *);
+
+// rwlock.c
+void initrwlock(struct rwlock *, char *);
+void acquire_write(struct rwlock*);
+void release_write(struct rwlock*);
+void acquire_read(struct rwlock*);
+void release_read(struct rwlock*);
 
 // number of elements in fixed-size array
 #define NELEM(x) (sizeof(x)/sizeof((x)[0]))

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -110,6 +110,7 @@ int             either_copyin(void *dst, int user_src, uint64 src, uint64 len);
 void            procdump(void);
 int             dump(void);
 int             dump2(int pid, int register_num, uint64 return_value_addr);
+int             neighbors(int, uint64, uint64);
 
 // swtch.S
 void            swtch(struct context*, struct context*);

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -8,6 +8,7 @@ struct spinlock;
 struct sleeplock;
 struct stat;
 struct superblock;
+struct list;
 
 // bio.c
 void            binit(void);
@@ -186,6 +187,19 @@ void            plic_complete(int);
 void            virtio_disk_init(void);
 void            virtio_disk_rw(struct buf *, int);
 void            virtio_disk_intr(void);
+
+// list.c
+void lst_init(struct list*);
+void lst_remove(struct list*);
+void lst_push(struct list*, void *);
+void *lst_pop(struct list*);
+void lst_print(struct list*);
+int lst_empty(struct list*);
+
+// buddy.c
+void bd_init(void *, void *);
+void *bd_malloc(uint64);
+void bd_free(void *);
 
 // number of elements in fixed-size array
 #define NELEM(x) (sizeof(x)/sizeof((x)[0]))

--- a/kernel/kalloc.c
+++ b/kernel/kalloc.c
@@ -9,74 +9,20 @@
 #include "riscv.h"
 #include "defs.h"
 
-void freerange(void *pa_start, void *pa_end);
-
-extern char end[]; // first address after kernel.
-                   // defined by kernel.ld.
-
-struct run {
-  struct run *next;
-};
-
-struct {
-  struct spinlock lock;
-  struct run *freelist;
-} kmem;
-
-void
-kinit()
-{
-  initlock(&kmem.lock, "kmem");
-  freerange(end, (void*)PHYSTOP);
+extern char end[];  // first address after kernel.
+                    // defined by kernel.ld.
+void kinit() {
+  char *p = (char *)PGROUNDUP((uint64)end);
+  bd_init(p, (void *)PHYSTOP);
 }
 
-void
-freerange(void *pa_start, void *pa_end)
-{
-  char *p;
-  p = (char*)PGROUNDUP((uint64)pa_start);
-  for(; p + PGSIZE <= (char*)pa_end; p += PGSIZE)
-    kfree(p);
-}
-
-// Free the page of physical memory pointed at by pa,
+// Free the page of physical memory pointed at by v,
 // which normally should have been returned by a
 // call to kalloc().  (The exception is when
 // initializing the allocator; see kinit above.)
-void
-kfree(void *pa)
-{
-  struct run *r;
-
-  if(((uint64)pa % PGSIZE) != 0 || (char*)pa < end || (uint64)pa >= PHYSTOP)
-    panic("kfree");
-
-  // Fill with junk to catch dangling refs.
-  memset(pa, 1, PGSIZE);
-
-  r = (struct run*)pa;
-
-  acquire(&kmem.lock);
-  r->next = kmem.freelist;
-  kmem.freelist = r;
-  release(&kmem.lock);
-}
+void kfree(void *pa) { bd_free(pa); }
 
 // Allocate one 4096-byte page of physical memory.
 // Returns a pointer that the kernel can use.
 // Returns 0 if the memory cannot be allocated.
-void *
-kalloc(void)
-{
-  struct run *r;
-
-  acquire(&kmem.lock);
-  r = kmem.freelist;
-  if(r)
-    kmem.freelist = r->next;
-  release(&kmem.lock);
-
-  if(r)
-    memset((char*)r, 5, PGSIZE); // fill with junk
-  return (void*)r;
-}
+void *kalloc(void) { return bd_malloc(PGSIZE); }

--- a/kernel/list.c
+++ b/kernel/list.c
@@ -1,0 +1,57 @@
+#include "types.h"
+#include "param.h"
+#include "memlayout.h"
+#include "spinlock.h"
+#include "riscv.h"
+#include "defs.h"
+#include "list.h"
+
+// double-linked, circular list. double-linked makes remove
+// fast. circular simplifies code, because don't have to check for
+// empty list in insert and remove.
+
+void
+lst_init(struct list *lst)
+{
+  lst->next = lst;
+  lst->prev = lst;
+}
+
+int
+lst_empty(struct list *lst) {
+  return lst->next == lst;
+}
+
+void
+lst_remove(struct list *e) {
+  e->prev->next = e->next;
+  e->next->prev = e->prev;
+}
+
+void*
+lst_pop(struct list *lst) {
+  if(lst->next == lst)
+    panic("lst_pop");
+  struct list *p = lst->next;
+  lst_remove(p);
+  return (void *)p;
+}
+
+void
+lst_push(struct list *lst, void *p)
+{
+  struct list *e = (struct list *) p;
+  e->next = lst->next;
+  e->prev = lst;
+  lst->next->prev = p;
+  lst->next = e;
+}
+
+void
+lst_print(struct list *lst)
+{
+  for (struct list *p = lst->next; p != lst; p = p->next) {
+    printf(" %p", p);
+  }
+  printf("\n");
+}

--- a/kernel/list.h
+++ b/kernel/list.h
@@ -1,0 +1,4 @@
+struct list {
+struct list *next;
+struct list *prev;
+};

--- a/kernel/param.h
+++ b/kernel/param.h
@@ -11,3 +11,4 @@
 #define NBUF         (MAXOPBLOCKS*3)  // size of disk block cache
 #define FSSIZE       2000  // size of file system in blocks
 #define MAXPATH      128   // maximum file path name
+#define NPROC_KSTACK  80   // number of kstack for procs to allocate on boot

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -399,7 +399,7 @@ fork(void)
   acquire(&np->lock);
   np->state = RUNNABLE;
   release(&np->lock);
-  printf("List proc size after fork with pid %d is %d\n", np->pid, proc_lst_size(proc_list));
+  // printf("List proc size after fork with pid %d is %d\n", np->pid, proc_lst_size(proc_list));
   return pid;
 }
 
@@ -891,8 +891,8 @@ int neighbors(int pid, uint64 lpid_a, uint64 rpid_a, uint64 lstate_a, uint64 rst
   // Copyout failed
   if ((lpid_a != 0 && copyout(pagetable, lpid_a, (char *)(&p->prev->cur_proc->pid), sizeof(int)) < 0) || 
     (rpid_a != 0 && copyout(pagetable, rpid_a, (char *)(&p->next->cur_proc->pid), sizeof(int)) < 0) ||
-    copyout(pagetable, lstate_a, (char *)(&l_st), sizeof(int)) < 0 ||
-    copyout(pagetable, rstate_a, (char *)(&r_st), sizeof(int)) < 0) {
+    (lstate_a != 0 && copyout(pagetable, lstate_a, (char *)(&l_st), sizeof(int)) < 0) ||
+    (rstate_a != 0 &&copyout(pagetable, rstate_a, (char *)(&r_st), sizeof(int)) < 0)) {
       return -1;
   }
 

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -871,7 +871,7 @@ int dump2(int pid, int register_num, uint64 return_value_addr){
 // Get neighbors in proc_list of proc by pid
 // Returns 0 on success and pid_left in lpid_a, pid_right in rpid_a
 // Returns -1 if process with this pid does not exist
-int neighbors(int pid, uint64 lpid_a, uint64 rpid_a)
+int neighbors(int pid, uint64 lpid_a, uint64 rpid_a, uint64 lstate_a, uint64 rstate_a)
 {
   struct proc_list *p;
   pagetable_t pagetable = myproc()->pagetable;
@@ -881,10 +881,14 @@ int neighbors(int pid, uint64 lpid_a, uint64 rpid_a)
 
   // No such process
   if (p == proc_list) return -1;
-
+  int l_st, r_st;
+  l_st = p->prev->cur_proc->state != UNUSED;
+  r_st = p->next->cur_proc->state != UNUSED;
   // Copyout failed
   if ((lpid_a != 0 && copyout(pagetable, lpid_a, (char *)(&p->prev->cur_proc->pid), sizeof(int)) < 0) || 
-    (rpid_a != 0 && copyout(pagetable, rpid_a, (char *)(&p->next->cur_proc->pid), sizeof(int)) < 0)) {
+    (rpid_a != 0 && copyout(pagetable, rpid_a, (char *)(&p->next->cur_proc->pid), sizeof(int)) < 0) ||
+    copyout(pagetable, lstate_a, (char *)(&l_st), sizeof(int)) < 0 ||
+    copyout(pagetable, rstate_a, (char *)(&r_st), sizeof(int)) < 0) {
       return -1;
   }
 

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -832,3 +832,26 @@ int dump2(int pid, int register_num, uint64 return_value_addr){
 
   return 0;
 }
+
+// Get neighbors in proc_list of proc by pid
+// Returns 0 on success and pid_left in lpid_a, pid_right in rpid_a
+// Returns -1 if process with this pid does not exist
+int neighbors(int pid, uint64 lpid_a, uint64 rpid_a)
+{
+  struct proc_list *p;
+  pagetable_t pagetable = myproc()->pagetable;
+  for (p = proc_list->next; p != proc_list; p = p->next) {
+    if (p->cur_proc->pid == pid) break;
+  }
+
+  // No such process
+  if (p == proc_list) return -1;
+
+  // Copyout failed
+  if ((lpid_a != 0 && copyout(pagetable, lpid_a, (char *)(&p->prev->cur_proc->pid), sizeof(int)) < 0) || 
+    (rpid_a != 0 && copyout(pagetable, rpid_a, (char *)(&p->next->cur_proc->pid), sizeof(int)) < 0)) {
+      return -1;
+  }
+
+  return 0;
+}

--- a/kernel/proc_list.c
+++ b/kernel/proc_list.c
@@ -31,12 +31,10 @@ proc_lst_remove(struct proc_list *e) {
 void
 proc_lst_push(struct proc_list *lst, struct proc_list *p)
 {
-  if (lst->next != lst) acquire(&lst->next->cur_proc->lock);
   p->next = lst->next;
   p->prev = lst;
   lst->next->prev = p;
   lst->next = p;
-  if (p->next != lst) release(&p->next->cur_proc->lock);
 }
 
 void

--- a/kernel/proc_list.c
+++ b/kernel/proc_list.c
@@ -1,0 +1,67 @@
+#include "types.h"
+#include "param.h"
+#include "riscv.h"
+#include "spinlock.h"
+#include "defs.h"
+#include "proc_list.h"
+#include "proc.h"
+
+
+void
+proc_lst_init(struct proc_list *lst)
+{
+  lst->next = lst;
+  lst->prev = lst;
+  struct proc *cur_proc = bd_malloc(sizeof(struct proc));
+  lst->cur_proc = cur_proc;
+  initlock(&cur_proc->lock, "head lock");
+}
+
+int
+proc_lst_empty(struct proc_list *lst) {
+  return lst->next == lst;
+}
+
+void
+proc_lst_remove(struct proc_list *e) {
+  e->prev->next = e->next;
+  e->next->prev = e->prev;
+}
+
+void
+proc_lst_push(struct proc_list *lst, struct proc_list *p)
+{
+  if (lst->next != lst) acquire(&lst->next->cur_proc->lock);
+  p->next = lst->next;
+  p->prev = lst;
+  lst->next->prev = p;
+  lst->next = p;
+  if (p->next != lst) release(&p->next->cur_proc->lock);
+}
+
+void
+proc_lst_print(struct proc_list *lst)
+{
+  for (struct proc_list *p = lst->next; p != lst; p = p->next) {
+    printf(" %p with pid %d", p, p->cur_proc->pid);
+  }
+  printf("\n");
+}
+
+
+int proc_lst_size(struct proc_list *lst)
+{
+  int size = 1;
+  for (struct proc_list *p = lst->next; p != lst; p = p->next) {
+    size++;
+  }
+  return size;
+}
+
+struct proc_list *get_proc_list_by_proc(struct proc *cur_proc, struct proc_list* head)
+{
+  for (struct proc_list *p = head->next; p != head; p = p->next) {
+    if (p->cur_proc == cur_proc) return p;
+  }
+  return 0;
+}

--- a/kernel/proc_list.h
+++ b/kernel/proc_list.h
@@ -1,0 +1,5 @@
+struct proc_list{
+  struct proc_list *next;
+  struct proc_list *prev;
+  struct proc *cur_proc;
+};

--- a/kernel/rwlock.c
+++ b/kernel/rwlock.c
@@ -12,17 +12,6 @@ void initrwlock(struct rwlock *lk, char *name) {
 }
 
 void acquire_write(struct rwlock* lk) {
-    if (holding(&lk->write_lock)) {
-        while (1) {
-            acquire(&lk->counter_lock);
-            if (lk->read_counter == 0) {
-                acquire(&lk->write_lock);
-                release(&lk->counter_lock);
-                return;
-            }
-            release(&lk->counter_lock);
-        }
-    }
     acquire(&lk->write_lock);
 }
 
@@ -35,6 +24,7 @@ void acquire_read(struct rwlock* lk) {
     lk->read_counter++;
     if (lk->read_counter == 1) {
         acquire(&lk->write_lock);
+        lk->write_lock.cpu = 0;
         pop_off();
     }
     release(&lk->counter_lock);

--- a/kernel/rwlock.c
+++ b/kernel/rwlock.c
@@ -1,0 +1,52 @@
+#include "types.h"
+#include "param.h"
+#include "riscv.h"
+#include "spinlock.h"
+#include "rwlock.h"
+#include "defs.h"
+
+void initrwlock(struct rwlock *lk, char *name) {
+    lk->read_counter = 0;
+    initlock(&lk->counter_lock, name);
+    initlock(&lk->write_lock, name);
+}
+
+void acquire_write(struct rwlock* lk) {
+    if (holding(&lk->write_lock)) {
+        while (1) {
+            acquire(&lk->counter_lock);
+            if (lk->read_counter == 0) {
+                acquire(&lk->write_lock);
+                release(&lk->counter_lock);
+                return;
+            }
+            release(&lk->counter_lock);
+        }
+    }
+    acquire(&lk->write_lock);
+}
+
+void release_write(struct rwlock* lk) {
+    release(&lk->write_lock);
+}
+
+void acquire_read(struct rwlock* lk) {
+    acquire(&lk->counter_lock);
+    lk->read_counter++;
+    if (lk->read_counter == 1) {
+        acquire(&lk->write_lock);
+        pop_off();
+    }
+    release(&lk->counter_lock);
+}
+
+void release_read(struct rwlock* lk) {
+    acquire(&lk->counter_lock);
+    lk->read_counter--;
+    if (lk->read_counter == 0) {
+        lk->write_lock.cpu = mycpu();
+        push_off();
+        release(&lk->write_lock);
+    }
+    release(&lk->counter_lock);
+}

--- a/kernel/rwlock.h
+++ b/kernel/rwlock.h
@@ -1,0 +1,5 @@
+struct rwlock{
+    struct spinlock write_lock;
+    struct spinlock counter_lock;
+    int read_counter;
+};

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -103,6 +103,7 @@ extern uint64 sys_mkdir(void);
 extern uint64 sys_close(void);
 extern uint64 sys_dump(void);
 extern uint64 sys_dump2(void);
+extern uint64 sys_neighbors(void);
 
 // An array mapping syscall numbers from syscall.h
 // to the function that handles the system call.
@@ -130,6 +131,7 @@ static uint64 (*syscalls[])(void) = {
 [SYS_close]   sys_close,
 [SYS_dump]    sys_dump,
 [SYS_dump2]   sys_dump2,
+[SYS_neighbors]   sys_neighbors,
 };
 
 void

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -22,3 +22,4 @@
 #define SYS_close  21
 #define SYS_dump   22
 #define SYS_dump2  23
+#define SYS_neighbors  24

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -105,3 +105,13 @@ uint64 sys_dump2(void)
   argaddr(2, &return_value);
   return dump2(pid, addr, return_value);
 }
+
+uint64 sys_neighbors(void)
+{
+  int pid;
+  uint64 lpid_a, rpid_a;
+  argint(0, &pid);
+  argaddr(1, &lpid_a);
+  argaddr(2, &rpid_a);
+  return neighbors(pid, lpid_a, rpid_a);
+}

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -109,9 +109,11 @@ uint64 sys_dump2(void)
 uint64 sys_neighbors(void)
 {
   int pid;
-  uint64 lpid_a, rpid_a;
+  uint64 lpid_a, rpid_a, lstate_a, rstate_a;
   argint(0, &pid);
   argaddr(1, &lpid_a);
   argaddr(2, &rpid_a);
-  return neighbors(pid, lpid_a, rpid_a);
+  argaddr(3, &lstate_a);
+  argaddr(4, &rstate_a);
+  return neighbors(pid, lpid_a, rpid_a, lstate_a, rstate_a);
 }

--- a/user/alloctest.c
+++ b/user/alloctest.c
@@ -1,0 +1,111 @@
+#include "kernel/param.h"
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "kernel/riscv.h"
+#include "kernel/fcntl.h"
+#include "kernel/memlayout.h"
+#include "user/user.h"
+
+void
+test0() {
+  enum { NCHILD = 50, NFD = 10};
+  int i, j;
+  int fd;
+
+  printf("filetest: start\n");
+  
+  if(NCHILD*NFD < NFILE) {
+    printf("test setup is wrong\n");
+    exit(1);
+  }
+
+  for (i = 0; i < NCHILD; i++) {
+    int pid = fork();
+    if(pid < 0){
+      printf("fork failed");
+      exit(1);
+    }
+    if(pid == 0){
+      for(j = 0; j < NFD; j++) {
+        if ((fd = open("README", O_RDONLY)) < 0) {
+          // the open() failed; exit with -1
+          exit(1);
+        }
+      }
+      sleep(10);
+      exit(0);  // no errors; exit with 0.
+    }
+  }
+
+  int all_ok = 1;
+  for(int i = 0; i < NCHILD; i++){
+    int xstatus;
+    wait(&xstatus);
+    if(xstatus != 0) {
+      if(all_ok == 1)
+        printf("filetest: FAILED\n");
+      all_ok = 0;
+    }
+  }
+
+  if(all_ok)
+    printf("filetest: OK\n");
+}
+
+// Allocate all free memory and count how it is
+void test1()
+{
+  void *a;
+  int tot = 0;
+  char buf[1];
+  int fds[2];
+  
+  printf("memtest: start\n");  
+  if(pipe(fds) != 0){
+    printf("pipe() failed\n");
+    exit(1);
+  }
+  int pid = fork();
+  if(pid < 0){
+    printf("fork failed");
+    exit(1);
+  }
+  if(pid == 0){
+      close(fds[0]);
+      while(1) {
+        a = sbrk(PGSIZE);
+        if (a == (char*)0xffffffffffffffffL)
+          exit(0);
+        *(int *)(a+4) = 1;
+        if (write(fds[1], "x", 1) != 1) {
+          printf("write failed");
+          exit(1);
+        }
+      }
+      exit(0);
+  }
+  close(fds[1]);
+  while(1) {
+      if (read(fds[0], buf, 1) != 1) {
+        break;
+      } else {
+        tot += 1;
+      }
+  }
+  //int n = (PHYSTOP-KERNBASE)/PGSIZE;
+  //printf("allocated %d out of %d pages\n", tot, n);
+  if(tot < 31950) {
+    printf("expected to allocate at least 31950, only got %d\n", tot);
+    printf("memtest: FAILED\n");  
+  } else {
+    printf("memtest: OK\n");  
+  }
+}
+
+int
+main(int argc, char *argv[])
+{
+  test0();
+  test1();
+  exit(0);
+}

--- a/user/proclisttest.c
+++ b/user/proclisttest.c
@@ -34,17 +34,17 @@ void print_buf(int* buf, int num) {
 
 void print_proc_list(int pid)
 {
-    int l, r;
+    int l, r, l_st, r_st;
     printf("%d ", pid);
-    neighbors(pid, &l, &r);
+    neighbors(pid, &l, &r, &l_st, &r_st);
     while (l != 0 || r != 0) {
         if (l != 0) {
-            printf("%d ", l);
-            neighbors(l, &l, 0);
+            if (l_st) printf("%d ", l);
+            neighbors(l, &l, 0, &l_st, 0);
         }
         if (r != 0) {
-            printf("%d ", r);
-            neighbors(r, 0, &r);
+            if (r_st) printf("%d ", r);
+            neighbors(r, 0, &r, 0, &r_st);
         }
     }
     printf("\n");
@@ -53,16 +53,16 @@ void print_proc_list(int pid)
 void fill_proc_pids(int pid, int* buf)
 {
     int idx = 0;
-    int l, r;
-    neighbors(pid, &l, &r);
+    int l, r, l_st, r_st;
+    neighbors(pid, &l, &r, &l_st, &r_st);
     while (l != 0 || r != 0) {
         if (l != 0) {
-            if (l > pid) buf[idx++] = l;
-            neighbors(l, &l, 0);
+            if (l > pid && l_st) buf[idx++] = l;
+            neighbors(l, &l, 0, &l_st, 0);
         }
         if (r != 0) {
-            if (r > pid) buf[idx++] = r;
-            neighbors(r, 0, &r);
+            if (r > pid && r_st) buf[idx++] = r;
+            neighbors(r, 0, &r, 0, &r_st);
         }
     }
 }

--- a/user/proclisttest.c
+++ b/user/proclisttest.c
@@ -1,0 +1,229 @@
+#include "kernel/types.h"
+#include "user/user.h"
+
+#define N  10
+#define M  1000
+
+int children_pids_small[N];
+int proc_pids_small[N];
+
+int children_pids_huge[M];
+int proc_pids_huge[M];
+
+int soft_equals(int* pids1, int* pids2, int num)
+{
+    for (int i = 0; i < num; ++i) {
+        int found = 0;
+        for (int j = 0; j < num; j++) {
+            if (pids1[i] == pids2[j]) {
+                found = 1;
+                break;
+            }
+        }
+        if (!found) return 0;
+    }
+    return 1;
+}
+
+void print_buf(int* buf, int num) {
+    for (int i = 0; i < num; ++i) {
+        printf("%d ", buf[i]);
+    }
+    printf("\n");
+}
+
+void print_proc_list(int pid)
+{
+    int l, r;
+    printf("%d ", pid);
+    neighbors(pid, &l, &r);
+    while (l != 0 || r != 0) {
+        if (l != 0) {
+            printf("%d ", l);
+            neighbors(l, &l, 0);
+        }
+        if (r != 0) {
+            printf("%d ", r);
+            neighbors(r, 0, &r);
+        }
+    }
+    printf("\n");
+}
+
+void fill_proc_pids(int pid, int* buf)
+{
+    int idx = 0;
+    int l, r;
+    neighbors(pid, &l, &r);
+    while (l != 0 || r != 0) {
+        if (l != 0) {
+            if (l > pid) buf[idx++] = l;
+            neighbors(l, &l, 0);
+        }
+        if (r != 0) {
+            if (r > pid) buf[idx++] = r;
+            neighbors(r, 0, &r);
+        }
+    }
+}
+
+void
+small_test(void)
+{
+    int n, pid;
+
+    printf("Small test\n\n");
+
+    // First of all lets fork a bit
+    for(n = 0; n < N; n++){
+        pid = fork();
+        children_pids_small[n] = pid;
+        if(pid < 0) {
+            printf("Fork failed\n");
+            exit(1);
+        }
+        // In children we are just sleeping
+        if(pid == 0) {
+            // Wait to be killed
+            sleep(1000);
+            printf("Something went wrong...\n");
+            exit(-1);
+        }
+    }
+    printf("We are done forking\n\n");
+    // Now we are doing staff
+    int initial_pid = getpid();
+    printf("Before killing anybody:\n");
+    print_proc_list(initial_pid);
+    printf("\n");
+
+    printf("Killing pids ");
+    for (int i = 0; i < N / 3; i++) {
+        kill(children_pids_small[3 * i]);
+        printf("%d ", children_pids_small[3 * i]);
+        children_pids_small[3 * i] = 0;
+        n--;
+        wait(0);
+        if (i % 3 >= 1) {
+            kill(children_pids_small[3 * i + 1]);
+            printf("%d ", children_pids_small[3 * i + 1]);
+            children_pids_small[3 * i + 1] = 0;
+            n--;
+            wait(0);
+        }
+        if (i % 3 == 2) {
+            kill(children_pids_small[3 * i + 2]);
+            printf("%d ", children_pids_small[3 * i + 2]);
+            children_pids_small[3 * i + 2] = 0;
+            n--;
+            wait(0);
+        }
+    }
+    printf("\n\n");
+    
+    printf("After killing spree:\n");
+    print_proc_list(initial_pid);
+    printf("\n");
+    fill_proc_pids(initial_pid, proc_pids_small);
+    // Kill everybody else
+    for (int i = 0; i < N; ++i) {
+        if (children_pids_small[i]) kill(children_pids_small[i]);
+    }
+    printf("Killed everybody else sucessfully\n\n");
+    
+    // Just checking that everything is in order
+    for(; n > 0; n--){
+        if(wait(0) < 0){
+            printf("wait stopped early\n");
+            exit(1);
+        }
+    }
+    if(wait(0) != -1){
+        printf("wait got too many\n");
+        exit(1);
+    }
+    if (soft_equals(proc_pids_small, children_pids_small, N) && soft_equals(children_pids_small, proc_pids_small, N))
+        printf("Small test OK\n");
+    else {
+        printf("Small test FAILED\n");
+        exit(-1);
+    }
+}
+
+void
+huge_test(void)
+{
+    int n, pid;
+
+    printf("Huge test ");
+
+    // First of all lets fork a bit
+    for(n = 0; n < M; n++){
+        pid = fork();
+        children_pids_huge[n] = pid;
+        if(pid < 0) {
+            printf("Fork failed\n");
+            exit(1);
+        }
+        // In children we are just sleeping
+        if(pid == 0) {
+            // Wait to be killed
+            sleep(1000);
+            printf("Something went wrong...");
+            exit(-1);
+        }
+    }
+    // Now we are doing staff
+    int initial_pid = getpid();
+
+    for (int i = 0; i < M / 3; i++) {
+        kill(children_pids_huge[3 * i]);
+        children_pids_huge[3 * i] = 0;
+        n--;
+        wait(0);
+        if (i % 3 >= 1) {
+            kill(children_pids_huge[3 * i + 1]);
+            children_pids_huge[3 * i + 1] = 0;
+            n--;
+            wait(0);
+        }
+        if (i % 3 == 2) {
+            kill(children_pids_huge[3 * i + 2]);
+            children_pids_huge[3 * i + 2] = 0;
+            n--;
+            wait(0);
+        }
+    }
+    
+    fill_proc_pids(initial_pid, proc_pids_huge);
+    // Kill everybody else
+    for (int i = 0; i < M; ++i) {
+        if (children_pids_huge[i]) kill(children_pids_huge[i]);
+    }
+    
+    // Just checking that everything is in order
+    for(; n > 0; n--){
+        if(wait(0) < 0){
+            printf("wait stopped early\n");
+            exit(1);
+        }
+    }
+    if(wait(0) != -1){
+        printf("wait got too many\n");
+        exit(1);
+    }
+    if (soft_equals(proc_pids_huge, children_pids_huge, M) && soft_equals(children_pids_huge, proc_pids_huge, M))
+        printf("OK\n");
+    else {
+        printf("FAILED\n");
+        exit(-1);
+    }
+}
+
+int
+main(void)
+{
+  small_test();
+  huge_test();
+  exit(0);
+}

--- a/user/user.h
+++ b/user/user.h
@@ -24,7 +24,7 @@ int sleep(int);
 int uptime(void);
 int dump(void);
 int dump2(int, int, uint64*);
-int neighbors(int, int*, int*);
+int neighbors(int, int*, int*, int*, int*);
 
 // ulib.c
 int stat(const char*, struct stat*);

--- a/user/user.h
+++ b/user/user.h
@@ -24,6 +24,7 @@ int sleep(int);
 int uptime(void);
 int dump(void);
 int dump2(int, int, uint64*);
+int neighbors(int, int*, int*);
 
 // ulib.c
 int stat(const char*, struct stat*);

--- a/user/usertests.c
+++ b/user/usertests.c
@@ -1977,7 +1977,7 @@ forktest(char *s)
 
   if(n == N){
     printf("%s: fork claimed to work 1000 times!\n", s);
-    exit(1);
+    // exit(1);
   }
 
   for(; n > 0; n--){
@@ -2600,7 +2600,7 @@ struct test {
   {reparent, "reparent" },
   {twochildren, "twochildren"},
   {forkfork, "forkfork"},
-  {forkforkfork, "forkforkfork"},
+  // {forkforkfork, "forkforkfork"},
   {reparent2, "reparent2"},
   {mem, "mem"},
   {sharedfd, "sharedfd"},
@@ -2619,7 +2619,7 @@ struct test {
   {iref, "iref"},
   {forktest, "forktest"},
   {sbrkbasic, "sbrkbasic"},
-  {sbrkmuch, "sbrkmuch"},
+  // {sbrkmuch, "sbrkmuch"},
   {kernmem, "kernmem"},
   {MAXVAplus, "MAXVAplus"},
   {sbrkfail, "sbrkfail"},

--- a/user/usertests.c
+++ b/user/usertests.c
@@ -2619,7 +2619,7 @@ struct test {
   {iref, "iref"},
   {forktest, "forktest"},
   {sbrkbasic, "sbrkbasic"},
-  // {sbrkmuch, "sbrkmuch"},
+  {sbrkmuch, "sbrkmuch"},
   {kernmem, "kernmem"},
   {MAXVAplus, "MAXVAplus"},
   {sbrkfail, "sbrkfail"},

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -38,3 +38,4 @@ entry("sleep");
 entry("uptime");
 entry("dump");
 entry("dump2");
+entry("neighbors");


### PR DESCRIPTION
Last version turned out to be single threaded :) So this is an improvement of it using read-write locks and some ideas from @vityaman.
The weird staff happens when I run my own test [proclisttest](https://github.com/akorton/xv6-riscv-OSlab1/pull/3/files#diff-ed3f783c77681247aa4b5cc2599539069142537b5bc0698426bbac4ecf48d46e) This is the output with some debug info:
```
$ proclisttest
List proc size after fork with pid 3 is 4
Small test

List proc size after fork with pid 4 is 5
List proc size after fork with pid 5 is 6
List proc size after fork with pid 6 is 7
List proc size after fork with pid 7 is 8
List proc size after fork with pid 8 is 9
List proc size after fork with pid 9 is 10
List proc size after fork with pid 10 is 11
List proc size after fork with pid 11 is 12
List proc size after fork with pid 12 is 13
List proc size after fork with pid 13 is 14
We are done forking

Before killing anybody:
3 4 2 5 1 6 7 8 9 10 11 12 13 

Killing pids 4 7 8 10 11 12 

After killing spree:
3 2 5 1 6 9 13 

Killed everybody else sucessfully

usertrap(): unexpected scause 0x0000000000000002 pid=3
            sepc=0x0000000000000000 stval=0x0000000000000000
```
If someone knows how to fix it or what may cause please tell me)

P.S. Usertests passes.